### PR TITLE
fix: allocate additional cpu shares & memory

### DIFF
--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -2,8 +2,8 @@ version: 1
 task_definition:
   services:
     tc-or-grpc-server:
-      cpu_shares: 400
-      mem_limit: 2G
+      cpu_shares: 737
+      mem_limit: 3525M
     tc-autopilot:
-      cpu_shares: 600
-      mem_limit: 2GB
+      cpu_shares: 1106
+      mem_limit: 3525M


### PR DESCRIPTION
- leaving out 10% of the CPU and Memory allocated to the cluster for building the java application